### PR TITLE
Style description field for drag'n'drop

### DIFF
--- a/app/assets/stylesheets/content/work_package_details/_attachments_tab.sass
+++ b/app/assets/stylesheets/content/work_package_details/_attachments_tab.sass
@@ -54,12 +54,5 @@
   border-top: 1px solid #ddd
 
 .is-droppable
-  transition: background 0.2s ease, border 0.2s ease
-  border: 1px dotted #35c53f
-  background: #d8fdd1 !important
-  form
-    background: white
-    textarea
-      background: #e6fde4
-      border: 0
+  border: 1px dotted $nm-color-success-border
 


### PR DESCRIPTION
This changes the styling of the dragging area. Basically the green background has been removed. The green border and cursor should be indicator enough.
